### PR TITLE
Add pyproject.toml and package install scaffold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,1 +1,17 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
 
+[project]
+name = "macro_regime"
+version = "0.1.0"
+description = "Regime-based macroeconomic analysis project"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = []
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
Adds a minimal pyproject.toml to make the repo installable with pip install -e .

- Configures setuptools build system
- Uses src/ package layout
- Enables imports from macro_regime