### PR TITLE
Fix README install command to use editable install with dev extras

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,9 +32,9 @@ Charles Stewart, Gianna Gatling, Muhammad Rashid, Leo Lee, David Okorie, Ethan O
 **Installation**
 
 ```bash
-git clone https://github.com/your-username/your-repo-name.git
-cd your-repo-name
-pip install pandas numpy matplotlib
+git clone https://github.com/carpet155/macro_regime_project.git
+cd macro_regime_project
+python -m pip install -e ".[dev]"
 ```
 ---
 ## Data Sources 


### PR DESCRIPTION
## Summary
- Replaces `pip install pandas numpy matplotlib` with `python -m pip install -e ".[dev]"` in `docs/README.md`
- Fixes placeholder repo URL to use the actual repo URL
- `python -m pip` ensures correct interpreter, `-e` enables editable mode, `.[dev]` pulls in dev dependencies from `pyproject.toml`

Closes #104

## Test plan
- [ ] Verify `docs/README.md` shows the updated install command
- [ ] Run `python -m pip install -e ".[dev]"` on a clean clone to confirm it works