### PR TITLE
Fix pct_change FutureWarning by passing fill_method=None

### DIFF
--- a/src/macro_regime/clean.py
+++ b/src/macro_regime/clean.py
@@ -141,7 +141,7 @@ def compute_returns(series: pd.Series, method: str = "simple") -> pd.Series:
     """Vectorized simple or log returns; first observation is NaN, index aligned to input."""
     s = series.astype(float)
     if method == "simple":
-        return s.pct_change()
+        return s.pct_change(fill_method=None)
     if method == "log":
         with np.errstate(divide="ignore", invalid="ignore"):
             return np.log(s / s.shift(1))


### PR DESCRIPTION
## Summary
- Replaces `s.pct_change()` with `s.pct_change(fill_method=None)` in `compute_returns` (`src/macro_regime/clean.py:144`).
- Silences the pandas FutureWarning that fired 12 times during pipeline runs.
- Stops forward-filling NaN price gaps before computing returns, so gap days now propagate NaN instead of producing a misleading 0% return on the day after the gap.

## Why this is also the more correct semantics
With the prior (deprecated) default `fill_method='pad'`, a sequence like `[100, NaN, 102, 104]` would internally become `[100, 100, 102, 104]`, yielding returns `[NaN, 0%, 2%, ~1.96%]`. The 0% on the gap day is not a real observation. With `fill_method=None`, the same input now returns `[NaN, NaN, NaN, ~1.96%]`, which matches the NaN-on-gap behavior already asserted for the parallel `calculate_daily_returns` function in `tests/test_returns.py`.

## Test plan
- [x] `pytest -q` passes (141 passed, 1 skipped); no pct_change FutureWarning in test output.
- [x] Direct `compute_returns` call under `-W error::FutureWarning` runs cleanly.
- [x] Verified gap-handling: `compute_returns(pd.Series([100, NaN, 102, 104]))` -> `[NaN, NaN, NaN, 0.0196]`.
- [ ] Re-run full pipeline (`python -m macro_regime.pipeline`) and confirm no FutureWarning lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)